### PR TITLE
Hide URLs in email links

### DIFF
--- a/app/templates/emails/brief_clarification_question.html
+++ b/app/templates/emails/brief_clarification_question.html
@@ -15,9 +15,7 @@
   </div>
   
   <p>
-  You must publish this question with your answer on the ‘{{ brief_name }}’ page by {{ publish_by_date|dateformat }} at:<br>
-  {% set questions_url %}{{ request.host_url[:-1] }}{{ config['BASE_PREFIX'] }}/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/supplier-questions{% endset %}
-  <a href="{{ questions_url }}">{{ questions_url }}</a>
+  You must <a href="{{ request.host_url[:-1] }}{{ config['BASE_PREFIX'] }}/buyers/frameworks/{{ framework_slug }}/requirements/{{ lot_slug }}/{{ brief_id }}/supplier-questions">publish this question with your answer</a> on the '{{ brief_name }}' page by {{ publish_by_date|dateformat }}.
   </p>
 
   <p>

--- a/app/templates/emails/brief_clarification_question_confirmation.html
+++ b/app/templates/emails/brief_clarification_question_confirmation.html
@@ -15,9 +15,7 @@
   </div>
 
   <p>
-  Your question will be posted with the buyer’s answer on the ‘{{ brief_name }}’ page at:<br>
-  {% set brief_url %}{{ request.host_url[:-1] }}{{ config['BASE_PREFIX'] }}/{{ framework_slug }}/opportunities/{{ brief_id }}{% endset %}
-  <a href="{{ brief_url }}">{{ brief_url }}</a>
+  Your question will be posted with the buyer’s answer on the <a href="{{ request.host_url[:-1] }}{{ config['BASE_PREFIX'] }}/{{ framework_slug }}/opportunities/{{ brief_id }}">'{{ brief_name }}' page</a>.
   </p>
 
   <p>

--- a/app/templates/emails/create_user_email.html
+++ b/app/templates/emails/create_user_email.html
@@ -5,20 +5,19 @@
     <title>Create your Digital Marketplace account</title>
 </head>
 <body>
-Hello,
-<br /><br />
-You have requested a new supplier account on the Digital Marketplace.
-<br /><br />
-Click the link below to confirm your account.
-<br /><br />
-{{ url }}
-<br /><br />
-You must click this link within 7 days of receiving this email.
-<br /><br />
-This is an automated message. Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need help.
-<br /><br />
-Thanks,
-<br /><br />
-The Digital Marketplace Admin Team
+	<p>Hello,</p>
+
+	<p>You have requested a new supplier account on the Digital Marketplace.</p>
+
+	<p>Click <a href="{{ url }}">this link</a> to confirm your account.</p>
+
+	<p>You must click the above link within 7 days of receiving this email.</p>
+
+	<p>This is an automated message. Email <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a> if you need help.</p>
+
+	<p>
+	Thanks,<br>
+	<strong>The Digital Marketplace Admin Team</strong>
+	</p>
 </body>
 </html>

--- a/app/templates/emails/invite_user_email.html
+++ b/app/templates/emails/invite_user_email.html
@@ -5,20 +5,19 @@
     <title>Your Digital Marketplace invitation</title>
 </head>
 <body>
-Hello,
-<br /><br />
-{{ user }} has invited you to become a contributor for {{ supplier }} on the Digital Marketplace.
-<br /><br />
-To accept this invitation, please click the link below:
-<br /><br />
-{{ url }}
-<br /><br />
-You must click this link within 7 days of receiving this email.
-<br /><br />
-This is an automated message. Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> if you need help.
-<br /><br />
-Thanks,
-<br /><br />
-The Digital Marketplace team
+	<p>Hello,</p>
+
+	<p>{{ user }} has invited you to become a contributor for {{ supplier }} on the Digital Marketplace.</p>
+
+	<p>Please <a href="{{ url }}">click this link</a> to accept the invitation</p>
+
+	<p>You must click the above link within 7 days of receiving this email.</p>
+
+	<p>This is an automated message. Email <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a> if you need help.</p>
+
+	<p>
+	Thanks,<br>
+	<strong>The Digital Marketplace team</strong>
+	</p>
 </body>
 </html>

--- a/app/templates/emails/reset_password_email.html
+++ b/app/templates/emails/reset_password_email.html
@@ -5,24 +5,25 @@
     <title>Reset your Digital Marketplace password</title>
 </head>
 <body>
-Hello,
-<br /><br />
-You recently asked to reset your Digital Marketplace password.
-<br /><br />
+	<p>Hello,</p>
+
+	<p>You recently asked to reset your Digital Marketplace password.</p>
+
 {% if locked %}
-It looks like you failed to log in 5 times so your account has now been locked.
-Email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a> to unlock it.
-<br /><br />
+	<p>It looks like you failed to log in 5 times so your account has now been locked.</p>
+
+	<p>Email <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a> to unlock it.</p>
+
 {% else %}
-You can change your password now using the link below:
-<br /><br />
-{{ url }}
-<br /><br />
-You must click this link within 24 hours of receiving this email.
-<br /><br />
+	<p>You can change your password now by <a href="{{ url }}">clicking this link</a>.</p>
+
+	<p>You must click the above link within 24 hours of receiving this email.</p>
+
 {% endif %}
-Thanks,
-<br /><br />
-The Digital Marketplace team
+
+	<p>
+	Thanks,<br>
+	<strong>The Digital Marketplace team</strong>
+	</p>
 </body>
 </html>


### PR DESCRIPTION
This is a compromise while the official URLs are being decided.  I.e.,
it's essentially a branding issue.