### PR TITLE
Fix ASSET_PATH in Supplier frontend

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+import os
 import urlparse
 
 from flask import Flask, request
@@ -20,9 +21,10 @@ from app.main.helpers.frameworks import question_references
 
 
 def create_app(config_name):
+    asset_path = os.environ.get('ASSET_PATH', configs[config_name].ASSET_PATH)
     application = Flask(__name__,
                         static_folder='static/',
-                        static_url_path=configs[config_name].STATIC_URL_PATH)
+                        static_url_path=asset_path)
 
     init_app(
         application,

--- a/config.py
+++ b/config.py
@@ -59,8 +59,7 @@ class Config(object):
     RESET_PASSWORD_SALT = 'ResetPasswordSalt'
     INVITE_EMAIL_SALT = 'InviteEmailSalt'
 
-    STATIC_URL_PATH = URL_PREFIX + '/static'
-    ASSET_PATH = STATIC_URL_PATH + '/'
+    ASSET_PATH = URL_PREFIX + '/static'
 
     # Feature Flags
     RAISE_ERROR_ON_MISSING_FEATURES = True


### PR DESCRIPTION
This bug was caused by an inconsistency in the number of slashes in
ASSET_PATH in the Supplier frontend vs the Buyer frontend.