### PR TITLE
Make error pages on the Supplier frontend consistent with the Buyer frontend

### DIFF
--- a/app/templates/errors/404.html
+++ b/app/templates/errors/404.html
@@ -1,20 +1,23 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Page could not be found - Digital Marketplace{% endblock %}
+{% block page_title %}Page could not be found - Marketplace{% endblock %}
 
 {% block main_content %}
 
 <div class="error-page">
-  <header class="page-heading-smaller">
-    <h1>Page could not be found</h1>
-  </header>
-
-  <p>
-      Check you’ve entered the correct web address or start again on the Digital Marketplace homepage.
-  </p>
-  <p>
-      If you can’t find what you’re looking for, contact us at <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>
-  </p>
+    <div class="index-page grid-row">
+        <div class="column-two-thirds">
+            <header class="page-heading-smaller">
+                <h1>Page not found</h1>
+            </header>
+            <p>
+                Check you’ve entered the correct web address or start again on the <a href="{{ marketplace_home }}">Digital Marketplace homepage</a>.
+            </p>
+            <p>
+                If you can’t find what you're looking for, email <a href="mailto:marketplace@digital.gov.au?subject=Marketplace%20feedback" title="Please send feedback to marketplace@digital.gov.au">marketplace@digital.gov.au</a>
+            </p>
+        </div>
+    </div>
 </div>
 
 {% endblock %}

--- a/app/templates/errors/500.html
+++ b/app/templates/errors/500.html
@@ -1,16 +1,24 @@
 {% extends "_base_page.html" %}
 
-{% block page_title %}Sorry, we’re experiencing technical difficulties - Digital Marketplace{% endblock %}
+{% block page_title %}Sorry, we’re experiencing technical difficulties - Marketplace{% endblock %}
 
 {% block main_content %}
 
 <div class="error-page">
-  <header class="page-heading-smaller">
-    <h1>Sorry, we’re experiencing technical difficulties</h1>
-  </header>
-  <p>
-      Try again later.
-  </p>
+  <div class="index-page grid-row">
+    <div class="column-two-thirds">
+      <header class="page-heading-smaller">
+        <h1>Sorry, we're experiencing technical difficulties</h1>
+      </header>
+      <p>
+        {% if error_message %}
+          {{ error_message }}
+        {% else %}
+          Try again later.
+        {% endif %}
+      </p>
+    </div>
+  </div>
 </div>
 
 {% endblock %}

--- a/tests/app/main/test_frameworks.py
+++ b/tests/app/main/test_frameworks.py
@@ -1186,10 +1186,6 @@ class TestFrameworkUpdatesPage(BaseApplicationTest):
             )
 
             assert_equal(response.status_code, 503)
-            assert_true(
-                self.strip_all_whitespace(u"<h1>Sorry, we’re experiencing technical difficulties</h1>")
-                in self.strip_all_whitespace(response.get_data(as_text=True))
-            )
 
     def test_empty_messages_exist_if_no_files_returned(self, s3, data_api_client):
         data_api_client.get_framework.return_value = self.framework('open')


### PR DESCRIPTION
It would be nice to get rid of this duplication.