### PR TITLE
Prevent users from being able to change their ABN in the seller application

### DIFF
--- a/app/main/views/signup.py
+++ b/app/main/views/signup.py
@@ -200,6 +200,10 @@ def application_update(id, step=None):
     form_data = from_response(request)
     application = form_data['application'] if json else form_data
 
+    # remove the ABN to prevent changes by users, as they set this on signup
+    if 'abn' in application and not current_user.has_role('admin'):
+        del application['abn']
+
     try:
         del application['status']
     except KeyError:


### PR DESCRIPTION
This PR is related to:

https://github.com/AusDTO/dto-digitalmarketplace-frontend/pull/898
https://github.com/AusDTO/dto-digitalmarketplace-api/pull/733

Because ABN is provided on user signup now, this change will prevent the user from being able to change their ABN when editing their profile (but still allows admin accounts to do so).