### PR TITLE
Update utils commit hash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cssselect==1.0.1
 docutils==0.13.1
 git+https://github.com/AusDTO/dto-digitalmarketplace-apiclient.git@7e145229335408ed0522577f8e4b521a3e399a04#egg=dto_digitalmarketplace_apiclient==whatever
 git+https://github.com/AusDTO/dto-digitalmarketplace-content-loader.git@338fa3cab7f9e9a7dee56b5e05b6d47af62b6a10#egg=dto_digitalmarketplace_content_loader==whatever
-git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@e186d713f4aa637d5e6a5999023c3523a7b03482#egg=dto_digitalmarketplace_utils==whatever
+git+https://github.com/AusDTO/dto-digitalmarketplace-utils.git@d2aba413cd2c555307db2feba83bc4588225166b#egg=dto_digitalmarketplace_utils==whatever
 enum34==1.1.6
 Flask==1.0.2
 Flask-Caching==1.4.0


### PR DESCRIPTION
This pull request updates the hash pointing to the latest commit made in the [utils repository](https://github.com/AusDTO/dto-digitalmarketplace-utils/commits).